### PR TITLE
ethx capo on arbitrum

### DIFF
--- a/scripts/DeployArbitrum.s.sol
+++ b/scripts/DeployArbitrum.s.sol
@@ -9,6 +9,7 @@ import {CLRatePriceCapAdapter, IPriceCapAdapter} from '../src/contracts/CLRatePr
 
 library CapAdaptersCodeArbitrum {
   address public constant weETH_eETH_AGGREGATOR = 0x20bAe7e1De9c596f5F7615aeaa1342Ba99294e12;
+  address public constant ETHx_ETH_RATE_AGGREGATOR = 0x1f5C0C2CD2e9Ad1eE475660AF0bBa27aE7d87f5e;
 
   function weETHAdapterCode() internal pure returns (bytes memory) {
     return
@@ -30,10 +31,37 @@ library CapAdaptersCodeArbitrum {
         )
       );
   }
+
+  function ETHxAdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(CLRatePriceCapAdapter).creationCode,
+        abi.encode(
+          IPriceCapAdapter.CapAdapterParams({
+            aclManager: AaveV3Arbitrum.ACL_MANAGER,
+            baseAggregatorAddress: AaveV3ArbitrumAssets.WETH_ORACLE,
+            ratioProviderAddress: ETHx_ETH_RATE_AGGREGATOR,
+            pairDescription: 'Capped ETHx / ETH / USD',
+            minimumSnapshotDelay: 7 days,
+            priceCapParams: IPriceCapAdapter.PriceCapUpdateParams({
+              snapshotRatio: 1033812175710783086,
+              snapshotTimestamp: 1719927925, // 2th of July 2024
+              maxYearlyRatioGrowthPercent: 9_24
+            })
+          })
+        )
+      );
+  }
 }
 
 contract DeployWeEthArbitrum is ArbitrumScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeArbitrum.weETHAdapterCode());
+  }
+}
+
+contract DeployEthxArbitrum is ArbitrumScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeArbitrum.ETHxAdapterCode());
   }
 }

--- a/tests/arbitrum/ETHxArbitrumPriceCapAdapterTest.t.sol
+++ b/tests/arbitrum/ETHxArbitrumPriceCapAdapterTest.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {AaveV3Arbitrum, AaveV3ArbitrumAssets} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {MiscArbitrum} from 'aave-address-book/MiscArbitrum.sol';
+
+import {IPriceCapAdapter} from '../../src/interfaces/IPriceCapAdapter.sol';
+import {CLAdapterBaseTest} from '../CLAdapterBaseTest.sol';
+import {CapAdaptersCodeArbitrum} from '../../scripts/DeployArbitrum.s.sol';
+
+contract ETHxArbitrumPriceCapAdapterTest is CLAdapterBaseTest {
+  constructor()
+    CLAdapterBaseTest(
+      CapAdaptersCodeArbitrum.ETHxAdapterCode(),
+      30,
+      ForkParams({network: 'arbitrum', blockNumber: 231208546}),
+      'ETHx_arbitrum'
+    )
+  {}
+}

--- a/tests/utils/GetExchangeRatesTest.t.sol
+++ b/tests/utils/GetExchangeRatesTest.t.sol
@@ -30,7 +30,7 @@ import {IOsTokenVaultController} from '../../src/interfaces/IOsTokenVaultControl
 import {IEthX} from '../../src/interfaces/IEthX.sol';
 
 import {CapAdaptersCodeEthereum} from '../../scripts/DeployEthereum.s.sol';
-import {CapAdaptersCodeArbitrum} from '../../scripts/DeployArbitrumWeEth.s.sol';
+import {CapAdaptersCodeArbitrum} from '../../scripts/DeployArbitrum.s.sol';
 import {CapAdaptersCodeBase} from '../../scripts/DeployBase.s.sol';
 
 contract ExchangeRatesEth is Test {
@@ -68,7 +68,7 @@ contract ExchangeRatesEth is Test {
 
 contract ExchangeRatesArbitrum is Test {
   function setUp() public {
-    vm.createSelectFork(vm.rpcUrl('arbitrum'), 194797824); // 27th of March
+    vm.createSelectFork(vm.rpcUrl('arbitrum'), 228000000); // 2th of july
   }
 
   function test_getExchangeRate() public view {
@@ -81,11 +81,15 @@ contract ExchangeRatesArbitrum is Test {
     uint256 weEthRate = uint256(
       IChainlinkAggregator(CapAdaptersCodeArbitrum.weETH_eETH_AGGREGATOR).latestAnswer()
     );
+    uint256 EthxRate = uint256(
+      IChainlinkAggregator(CapAdaptersCodeArbitrum.ETHx_ETH_RATE_AGGREGATOR).latestAnswer()
+    );
 
     console.log('Arbitrum');
     console.log('rEthRate', rEthRate);
     console.log('wstEthRate', wstEthRate);
     console.log('weEthRate', weEthRate);
+    console.log('EthxRate', EthxRate);
     console.log(block.timestamp);
   }
 }


### PR DESCRIPTION
the test test_latestAnswerRetrospective() for ETHx is failing with Invalid ratio timestamp, which I guess is normal as it try to deploy to an old block to get the ratio, and this old block is older than the ratio timestamp I provide, but am not sure what I should do next