### PR TITLE
feat: add capo for wstETH on bnb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ deploy-susds-mainnet :
 	forge script scripts/DeployEthereum.s.sol:DeployUSDSEthereum --rpc-url mainnet $(common-flags)
 	forge script scripts/DeployEthereum.s.sol:DeploysUSDSEthereum --rpc-url mainnet $(common-flags)
 
-deploy-wsteth-bnb :; forge script scripts/DeployBNB.s.sol:DeployWstEthBnb --rpc-url bnb $(common-flags)
+deploy-wsteth-bnb :; forge script scripts/DeployBnb.s.sol:DeployWstEthBnb --rpc-url bnb $(common-flags)
 
 # Utilities
 download :; cast etherscan-source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ deploy-susds-mainnet :
 	forge script scripts/DeployEthereum.s.sol:DeployUSDSEthereum --rpc-url mainnet $(common-flags)
 	forge script scripts/DeployEthereum.s.sol:DeploysUSDSEthereum --rpc-url mainnet $(common-flags)
 
+deploy-wsteth-bnb :; forge script scripts/DeployBNB.s.sol:DeployWstEthBnb --rpc-url bnb $(common-flags)
+
 # Utilities
 download :; cast etherscan-source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}
 git-diff :

--- a/reports/wstETH_BNB.md
+++ b/reports/wstETH_BNB.md
@@ -1,0 +1,18 @@
+# Capo Report
+
+| Capped wstETH / stETH(ETH) / USD | ETH / USD | Diff | Date | 7-day growth in yearly % |
+| --- | --- | --- | --- | --- |
+| 3133.78741239 | 2655.02535327 | 16.54% | 29 Sept 2024 | 3.41% |
+| 3081.12278712 | 2610.195 | 16.55% | 30 Sept 2024 | 3.38% |
+| 2965.32175918 | 2511.8853 | 16.56% | 01 Oct 2024 | 3.36% |
+
+
+* 7-day growth is calculated as an annualized percentage relative to the value of the rate 7 days prior. 
+
+
+| Max Yearly % | Max Day-to-day yearly % | Max 7-day yearly % | 
+| --- | --- | --- |
+| 9.68% | 5.60% | 3.41% | 
+
+
+* Max day-to-day yearly % indicates the maximum growth between two emissions as an annualized percentage. 

--- a/scripts/DeployBnb.s.sol
+++ b/scripts/DeployBnb.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {Script} from 'forge-std/Script.sol';
 import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
 import {BNBScript} from 'aave-helpers/ScriptUtils.sol';
-import {CLRatePriceCapAdapter, IPriceCapAdapter, IACLManager} from 'src/contracts/CLRatePriceCapAdapter.sol';
-import {AaveV3BNB} from 'aave-address-book/AaveV3BNB.sol';
+import {AaveV3BNB, AaveV3BNBAssets} from 'aave-address-book/AaveV3BNB.sol';
+
+import {CLRatePriceCapAdapter, IPriceCapAdapter, IACLManager} from '../src/contracts/CLRatePriceCapAdapter.sol';
 
 library CapAdaptersCodeBNB {
   address public constant ETH_USD_AGGREGATOR = 0x9ef1B8c0E4F7dc8bF5719Ea496883DC6401d5b2e;

--- a/scripts/DeployBnb.s.sol
+++ b/scripts/DeployBnb.s.sol
@@ -8,7 +8,6 @@ import {AaveV3BNB, AaveV3BNBAssets} from 'aave-address-book/AaveV3BNB.sol';
 import {CLRatePriceCapAdapter, IPriceCapAdapter, IACLManager} from '../src/contracts/CLRatePriceCapAdapter.sol';
 
 library CapAdaptersCodeBNB {
-  address public constant ETH_USD_AGGREGATOR = 0x9ef1B8c0E4F7dc8bF5719Ea496883DC6401d5b2e;
   address public constant wstETH_stETH_AGGREGATOR = 0x4c75d01cfa4D998770b399246400a6dc40FB9645;
 
   function wstETHAdapterCode() internal pure returns (bytes memory) {

--- a/scripts/DeployBnb.s.sol
+++ b/scripts/DeployBnb.s.sol
@@ -17,8 +17,8 @@ library CapAdaptersCodeBNB {
         type(CLRatePriceCapAdapter).creationCode,
         abi.encode(
           IPriceCapAdapter.CapAdapterParams({
-            aclManager: IACLManager(address(AaveV3BNB.ACL_MANAGER)),
-            baseAggregatorAddress: ETH_USD_AGGREGATOR,
+            aclManager: AaveV3BNB.ACL_MANAGER,
+            baseAggregatorAddress: AaveV3BNBAssets.ETH_ORACLE,
             ratioProviderAddress: wstETH_stETH_AGGREGATOR,
             pairDescription: 'Capped wstETH / stETH(ETH) / USD',
             minimumSnapshotDelay: 7 days,

--- a/scripts/DeployBnb.s.sol
+++ b/scripts/DeployBnb.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Script} from 'forge-std/Script.sol';
+import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
+import {BNBScript} from 'aave-helpers/ScriptUtils.sol';
+import {CLRatePriceCapAdapter, IPriceCapAdapter, IACLManager} from 'src/contracts/CLRatePriceCapAdapter.sol';
+import {AaveV3BNB} from 'aave-address-book/AaveV3BNB.sol';
+
+library CapAdaptersCodeBNB {
+  address public constant ETH_USD_AGGREGATOR = 0x9ef1B8c0E4F7dc8bF5719Ea496883DC6401d5b2e;
+  address public constant wstETH_stETH_AGGREGATOR = 0x4c75d01cfa4D998770b399246400a6dc40FB9645;
+
+  function wstETHAdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(CLRatePriceCapAdapter).creationCode,
+        abi.encode(
+          IPriceCapAdapter.CapAdapterParams({
+            aclManager: IACLManager(address(AaveV3BNB.ACL_MANAGER)),
+            baseAggregatorAddress: ETH_USD_AGGREGATOR,
+            ratioProviderAddress: wstETH_stETH_AGGREGATOR,
+            pairDescription: 'Capped wstETH / stETH(ETH) / USD',
+            minimumSnapshotDelay: 7 days,
+            priceCapParams: IPriceCapAdapter.PriceCapUpdateParams({
+              snapshotRatio: 1179619475032439052,
+              snapshotTimestamp: 1727049059, // Sep-22-2024
+              maxYearlyRatioGrowthPercent: 9_68
+            })
+          })
+        )
+      );
+  }
+}
+
+contract DeployWstEthBnb is BNBScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeBNB.wstETHAdapterCode());
+  }
+}

--- a/tests/bnb/wstETHPriceCapAdapterTest.t.sol
+++ b/tests/bnb/wstETHPriceCapAdapterTest.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import '../BaseTest.sol';
+import {CapAdaptersCodeBNB, CLRatePriceCapAdapter} from '../../scripts/DeployBNB.s.sol';
+
+contract wstETHPriceCapAdapterTest is BaseTest {
+  constructor()
+    BaseTest(
+      CapAdaptersCodeBNB.wstETHAdapterCode(),
+      9,
+      ForkParams({network: 'bnb', blockNumber: 42738754}),
+      'wstETH_BNB'
+    )
+  {}
+
+  function _createAdapter(
+    IPriceCapAdapter.CapAdapterParams memory capAdapterParams
+  ) internal override returns (IPriceCapAdapter) {
+    return new CLRatePriceCapAdapter(capAdapterParams);
+  }
+}

--- a/tests/bnb/wstETHPriceCapAdapterTest.t.sol
+++ b/tests/bnb/wstETHPriceCapAdapterTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import '../BaseTest.sol';
-import {CapAdaptersCodeBNB, CLRatePriceCapAdapter} from '../../scripts/DeployBNB.s.sol';
+import {CapAdaptersCodeBNB, CLRatePriceCapAdapter} from '../../scripts/DeployBnb.s.sol';
 
 contract wstETHPriceCapAdapterTest is BaseTest {
   constructor()

--- a/tests/utils/GetExchangeRatesTest.t.sol
+++ b/tests/utils/GetExchangeRatesTest.t.sol
@@ -33,6 +33,7 @@ import {CapAdaptersCodeEthereum} from '../../scripts/DeployEthereum.s.sol';
 import {CapAdaptersCodeArbitrum} from '../../scripts/DeployArbitrumWeEth.s.sol';
 import {CapAdaptersCodeBase} from '../../scripts/DeployBase.s.sol';
 import {CapAdaptersCodeScroll} from '../../scripts/DeployScroll.s.sol';
+import {CapAdaptersCodeBNB} from '../../scripts/DeployBnb.s.sol';
 
 contract ExchangeRatesEth is Test {
   function setUp() public {
@@ -223,6 +224,22 @@ contract ExchangeRatesScroll is Test {
     console.log('Scroll');
     console.log('wstEthRate', wstEthRate);
     console.log('weEthRate', weEthRate);
+    console.log(block.timestamp);
+  }
+}
+
+contract ExchangeRatesBNB is Test {
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('bnb'), 42490000); // Sep-22-2024
+  }
+
+  function test_getExchangeRate() public view {
+    uint256 wstEthRate = uint256(
+      IChainlinkAggregator(CapAdaptersCodeBNB.wstETH_stETH_AGGREGATOR).latestAnswer()
+    );
+
+    console.log('BNB');
+    console.log('wstEthRate', wstEthRate);
     console.log(block.timestamp);
   }
 }


### PR DESCRIPTION
Added scripts for deploying wstETH capo feed on BNB network.

_Please note: As the wstETH / stETH exchange rate feed has been deployed recently, the report generated is quite small._