### PR TITLE
feat: eur stable price cap adapter

### DIFF
--- a/scripts/DeployBase.s.sol
+++ b/scripts/DeployBase.s.sol
@@ -65,7 +65,7 @@ library CapAdaptersCodeBase {
             assetToUsdAggregator: IChainlinkAggregator(EURC_PRICE_FEED),
             baseToUsdAggregator: IChainlinkAggregator(EUR_PRICE_FEED),
             adapterDescription: 'Capped EURC/USD',
-            priceCap: int256(1.04 * 1e8)
+            priceCapRatio: int256(1.04 * 1e8)
           })
         )
       );

--- a/src/contracts/PriceCapAdapterStable.sol
+++ b/src/contracts/PriceCapAdapterStable.sol
@@ -40,7 +40,7 @@ contract PriceCapAdapterStable is IPriceCapAdapterStable {
   }
 
   /// @inheritdoc ICLSynchronicityPriceAdapter
-  function latestAnswer() external view override returns (int256) {
+  function latestAnswer() external view override virtual returns (int256) {
     int256 basePrice = ASSET_TO_USD_AGGREGATOR.latestAnswer();
     int256 priceCap = _priceCap;
 
@@ -74,7 +74,7 @@ contract PriceCapAdapterStable is IPriceCapAdapterStable {
    * @notice Updates price cap
    * @param priceCap the new price cap
    */
-  function _setPriceCap(int256 priceCap) internal {
+  function _setPriceCap(int256 priceCap) internal virtual {
     int256 basePrice = ASSET_TO_USD_AGGREGATOR.latestAnswer();
 
     if (priceCap < basePrice) {

--- a/src/contracts/misc-adapters/EURPriceCapAdapterStable.sol
+++ b/src/contracts/misc-adapters/EURPriceCapAdapterStable.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.19;
+
+import {PriceCapAdapterStable, IChainlinkAggregator, ICLSynchronicityPriceAdapter, IPriceCapAdapterStable} from '../PriceCapAdapterStable.sol';
+import {IEURPriceCapAdapterStable} from '../../interfaces/IEURPriceCapAdapterStable.sol';
+
+/**
+ * @title EURPriceCapAdapterStable
+ * @author BGD Labs
+ * @notice Price capped adapter to cap the price of the EUR asset using the
+ * @notice chainlink market feeds ASSET/USD and EUR/USD
+ */
+contract EURPriceCapAdapterStable is IEURPriceCapAdapterStable, PriceCapAdapterStable {
+  /// @inheritdoc IEURPriceCapAdapterStable
+  IChainlinkAggregator public immutable BASE_TO_USD_AGGREGATOR;
+
+  /**
+   * @param capAdapterStableParams parameters to create eur stable cap adapter
+   */
+  constructor(CapAdapterStableParamsEUR memory capAdapterStableParams)
+    PriceCapAdapterStable(
+      CapAdapterStableParams(
+        capAdapterStableParams.aclManager,
+        capAdapterStableParams.assetToUsdAggregator,
+        capAdapterStableParams.adapterDescription,
+        capAdapterStableParams.priceCap
+      )
+    ) {
+    BASE_TO_USD_AGGREGATOR = capAdapterStableParams.baseToUsdAggregator;
+  }
+
+  /// @inheritdoc ICLSynchronicityPriceAdapter
+  function latestAnswer() external view override(ICLSynchronicityPriceAdapter, PriceCapAdapterStable) virtual returns (int256) {
+    int256 assetPrice = ASSET_TO_USD_AGGREGATOR.latestAnswer();
+    int256 basePrice = BASE_TO_USD_AGGREGATOR.latestAnswer();
+    int256 maxPrice = (basePrice * _priceCap) / 1e8;
+
+    if (assetPrice > maxPrice) {
+      return maxPrice;
+    }
+
+    return assetPrice;
+  }
+
+  /**
+   * @notice Updates price cap
+   * @param priceCap the new price cap
+   */
+  function _setPriceCap(int256 priceCap) internal override {
+    int256 assetPrice = ASSET_TO_USD_AGGREGATOR.latestAnswer();
+    int256 basePrice = BASE_TO_USD_AGGREGATOR.latestAnswer();
+
+    if ((basePrice * priceCap) / 1e8 < assetPrice) {
+      revert CapLowerThanActualPrice();
+    }
+
+    _priceCap = priceCap;
+
+    emit PriceCapUpdated(priceCap);
+  }
+}

--- a/src/contracts/misc-adapters/EURPriceCapAdapterStable.sol
+++ b/src/contracts/misc-adapters/EURPriceCapAdapterStable.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.19;
 
-import {PriceCapAdapterStable, IChainlinkAggregator, ICLSynchronicityPriceAdapter, IPriceCapAdapterStable} from '../PriceCapAdapterStable.sol';
-import {IEURPriceCapAdapterStable} from '../../interfaces/IEURPriceCapAdapterStable.sol';
+import {IEURPriceCapAdapterStable, ICLSynchronicityPriceAdapter, IACLManager, IChainlinkAggregator} from '../../interfaces/IEURPriceCapAdapterStable.sol';
 
 /**
  * @title EURPriceCapAdapterStable
@@ -10,30 +9,46 @@ import {IEURPriceCapAdapterStable} from '../../interfaces/IEURPriceCapAdapterSta
  * @notice Price capped adapter to cap the price of the EUR asset using the
  * @notice chainlink market feeds ASSET/USD and EUR/USD
  */
-contract EURPriceCapAdapterStable is IEURPriceCapAdapterStable, PriceCapAdapterStable {
+contract EURPriceCapAdapterStable is IEURPriceCapAdapterStable {
+  /// @inheritdoc IEURPriceCapAdapterStable
+  IChainlinkAggregator public immutable ASSET_TO_USD_AGGREGATOR;
+
   /// @inheritdoc IEURPriceCapAdapterStable
   IChainlinkAggregator public immutable BASE_TO_USD_AGGREGATOR;
+
+  /// @inheritdoc IEURPriceCapAdapterStable
+  IACLManager public immutable ACL_MANAGER;
+
+  /// @inheritdoc ICLSynchronicityPriceAdapter
+  uint8 public decimals;
+
+  /// @inheritdoc ICLSynchronicityPriceAdapter
+  string public description;
+
+  int256 internal _priceCapRatio;
 
   /**
    * @param capAdapterStableParams parameters to create eur stable cap adapter
    */
-  constructor(CapAdapterStableParamsEUR memory capAdapterStableParams)
-    PriceCapAdapterStable(
-      CapAdapterStableParams(
-        capAdapterStableParams.aclManager,
-        capAdapterStableParams.assetToUsdAggregator,
-        capAdapterStableParams.adapterDescription,
-        capAdapterStableParams.priceCap
-      )
-    ) {
-    BASE_TO_USD_AGGREGATOR = capAdapterStableParams.baseToUsdAggregator;
+  constructor(CapAdapterStableParamsEUR memory capAdapterStableParams) {
+    if (address(capAdapterStableParams.aclManager) == address(0)) {
+      revert ACLManagerIsZeroAddress();
+    }
+
+    ASSET_TO_USD_AGGREGATOR = capAdapterStableParams.assetToUsdAggregator;
+    BASE_TO_USD_AGGREGATOR = capAdapterStableParams.assetToUsdAggregator;
+    ACL_MANAGER = capAdapterStableParams.aclManager;
+    description = capAdapterStableParams.adapterDescription;
+    decimals = ASSET_TO_USD_AGGREGATOR.decimals();
+
+    _setPriceCapRatio(capAdapterStableParams.priceCapRatio);
   }
 
   /// @inheritdoc ICLSynchronicityPriceAdapter
-  function latestAnswer() external view override(ICLSynchronicityPriceAdapter, PriceCapAdapterStable) virtual returns (int256) {
+  function latestAnswer() external view returns (int256) {
     int256 assetPrice = ASSET_TO_USD_AGGREGATOR.latestAnswer();
     int256 basePrice = BASE_TO_USD_AGGREGATOR.latestAnswer();
-    int256 maxPrice = (basePrice * _priceCap) / 1e8;
+    int256 maxPrice = (basePrice * _priceCapRatio) / 1e8;
 
     if (assetPrice > maxPrice) {
       return maxPrice;
@@ -42,20 +57,39 @@ contract EURPriceCapAdapterStable is IEURPriceCapAdapterStable, PriceCapAdapterS
     return assetPrice;
   }
 
+  /// @inheritdoc IEURPriceCapAdapterStable
+  function setPriceCapRatio(int256 priceCapRatio) external {
+    if (!ACL_MANAGER.isRiskAdmin(msg.sender) && !ACL_MANAGER.isPoolAdmin(msg.sender)) {
+      revert CallerIsNotRiskOrPoolAdmin();
+    }
+
+    _setPriceCapRatio(priceCapRatio);
+  }
+
+  /// @inheritdoc IEURPriceCapAdapterStable
+  function getPriceCapRatio() external view returns (int256) {
+    return _priceCapRatio;
+  }
+
+  /// @inheritdoc IEURPriceCapAdapterStable
+  function isCapped() public view virtual returns (bool) {
+    return (ASSET_TO_USD_AGGREGATOR.latestAnswer() > this.latestAnswer());
+  }
+
   /**
-   * @notice Updates price cap
-   * @param priceCap the new price cap
+   * @notice Updates price cap ratio
+   * @param priceCapRatio the new price cap ratio
    */
-  function _setPriceCap(int256 priceCap) internal override {
+  function _setPriceCapRatio(int256 priceCapRatio) internal virtual {
     int256 assetPrice = ASSET_TO_USD_AGGREGATOR.latestAnswer();
     int256 basePrice = BASE_TO_USD_AGGREGATOR.latestAnswer();
 
-    if ((basePrice * priceCap) / 1e8 < assetPrice) {
+    if ((basePrice * priceCapRatio) / 1e8 < assetPrice) {
       revert CapLowerThanActualPrice();
     }
 
-    _priceCap = priceCap;
+    _priceCapRatio = priceCapRatio;
 
-    emit PriceCapUpdated(priceCap);
+    emit PriceCapRatioUpdated(priceCapRatio);
   }
 }

--- a/src/interfaces/IEURPriceCapAdapterStable.sol
+++ b/src/interfaces/IEURPriceCapAdapterStable.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IPriceCapAdapterStable, IACLManager, IChainlinkAggregator} from './IPriceCapAdapterStable.sol';
+import {IACLManager} from 'aave-address-book/AaveV3.sol';
+import {IChainlinkAggregator} from 'cl-synchronicity-price-adapter/interfaces/IChainlinkAggregator.sol';
+import {ICLSynchronicityPriceAdapter} from 'cl-synchronicity-price-adapter/interfaces/ICLSynchronicityPriceAdapter.sol';
 
-interface IEURPriceCapAdapterStable is IPriceCapAdapterStable {
+interface IEURPriceCapAdapterStable is ICLSynchronicityPriceAdapter {
   /**
    * @notice Parameters to create eur stable cap adapter
    * @param capAdapterStableParams parameters to create eur stable cap adapter
@@ -13,11 +15,47 @@ interface IEURPriceCapAdapterStable is IPriceCapAdapterStable {
     IChainlinkAggregator assetToUsdAggregator;
     IChainlinkAggregator baseToUsdAggregator;
     string adapterDescription;
-    int256 priceCap;
+    int256 priceCapRatio;
   }
+
+  /**
+   * @dev Emitted when the price cap ratio gets updated
+   * @param priceCapRatio the new price cap ratio
+   **/
+  event PriceCapRatioUpdated(int256 priceCapRatio);
+
+  /**
+   * @notice Price feed for (ASSET / USD) pair
+   */
+  function ASSET_TO_USD_AGGREGATOR() external view returns (IChainlinkAggregator);
 
   /**
    * @notice Price feed for (BASE / USD) pair
    */
   function BASE_TO_USD_AGGREGATOR() external view returns (IChainlinkAggregator);
+
+  /**
+   * @notice ACL manager contract
+   */
+  function ACL_MANAGER() external view returns (IACLManager);
+
+  /**
+   * @notice Updates price cap ratio
+   * @param priceCapRatio the new price cap ratio
+   */
+  function setPriceCapRatio(int256 priceCapRatio) external;
+
+  /**
+   * @notice Get price cap ratio value
+   */
+  function getPriceCapRatio() external view returns (int256);
+
+  /**
+   * @notice Returns if the price is currently capped
+   */
+  function isCapped() external view returns (bool);
+
+  error ACLManagerIsZeroAddress();
+  error CallerIsNotRiskOrPoolAdmin();
+  error CapLowerThanActualPrice();
 }

--- a/src/interfaces/IEURPriceCapAdapterStable.sol
+++ b/src/interfaces/IEURPriceCapAdapterStable.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IPriceCapAdapterStable, IACLManager, IChainlinkAggregator} from './IPriceCapAdapterStable.sol';
+
+interface IEURPriceCapAdapterStable is IPriceCapAdapterStable {
+  /**
+   * @notice Parameters to create eur stable cap adapter
+   * @param capAdapterStableParams parameters to create eur stable cap adapter
+   */
+  struct CapAdapterStableParamsEUR {
+    IACLManager aclManager;
+    IChainlinkAggregator assetToUsdAggregator;
+    IChainlinkAggregator baseToUsdAggregator;
+    string adapterDescription;
+    int256 priceCap;
+  }
+
+  /**
+   * @notice Price feed for (BASE / USD) pair
+   */
+  function BASE_TO_USD_AGGREGATOR() external view returns (IChainlinkAggregator);
+}

--- a/tests/base/EURCPriceCapAdapter.t.sol
+++ b/tests/base/EURCPriceCapAdapter.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import '../BaseStableTest.sol';
+import {CapAdaptersCodeBase} from '../../scripts/DeployBase.s.sol';
+
+contract EURCBasePriceCapAdapterTest is BaseStableTest {
+  constructor()
+    BaseStableTest(
+      CapAdaptersCodeBase.EURCAdapterCode(),
+      10,
+      ForkParams({network: 'base', blockNumber: 26853575})
+    )
+  {}
+}


### PR DESCRIPTION
Added capo feeds for EUR based stable coins using asset/usd feed and eur/usd feed.

For EURC on base, the priceCapRatio is set to `1.04e8`, which means the price of `EURC/USD` will be capped if it will be greater than `EUR/USD * 1.04`