### PR TITLE
chore: sUSDe avax, pt-sUSDe pt-USDe plasma scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ deploy-rseth-arbitrum :; forge script scripts/DeployArbitrum.s.sol:DeployRsETHAr
 deploy-rseth-base :; forge script scripts/DeployBase.s.sol:DeployRsETHBase --rpc-url base $(common-flags)
 
 deploy-ausd-avalanche :; forge script scripts/DeployAvalanche.s.sol:DeployAUSDAvalanche --rpc-url avalanche $(common-flags)
-
+deploy-susde-avalanche :; forge script scripts/DeployAvalanche.s.sol:DeploySUSDeAvalanche --rpc-url avalanche $(common-flags)
 
 deploy-weeth-linea :; FOUNDRY_PROFILE=linea forge script scripts/DeployLinea.s.sol:DeployWeEthLinea --rpc-url linea $(common-flags)
 deploy-ezeth-linea :; FOUNDRY_PROFILE=linea forge script scripts/DeployLinea.s.sol:DeployEzEthLinea --rpc-url linea $(common-flags)
@@ -86,6 +86,8 @@ deploy-usdt-ink :; forge script scripts/DeployInk.s.sol:DeployUSDTInk --rpc-url 
 deploy-susde-plasma :; forge script scripts/DeployPlasma.s.sol:DeploySUSDePlasma --rpc-url plasma $(common-flags)
 deploy-weETH-plasma :; forge script scripts/DeployPlasma.s.sol:DeployWeEthPlasma --rpc-url plasma $(common-flags)
 deploy-usdt-plasma :; forge script scripts/DeployPlasma.s.sol:DeployUSDTPlasma --rpc-url plasma $(common-flags)
+deploy-pt-susde-15-jan-2026-plasma :; forge script scripts/DeployPlasma.s.sol:DeployPtSUSDe15JAN2026Plasma --rpc-url plasma $(common-flags)
+deploy-pt-usde-15-jan-2026-plasma :; forge script scripts/DeployPlasma.s.sol:DeployPtUSDe15JAN2026Plasma --rpc-url plasma $(common-flags)
 
 # Utilities
 download :; cast etherscan-source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}

--- a/scripts/DeployAvalanche.s.sol
+++ b/scripts/DeployAvalanche.s.sol
@@ -3,14 +3,16 @@ pragma solidity ^0.8.0;
 
 import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
 import {AvalancheScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
-import {AaveV3Avalanche} from 'aave-address-book/AaveV3Avalanche.sol';
+import {AaveV3Avalanche, AaveV3AvalancheAssets} from 'aave-address-book/AaveV3Avalanche.sol';
 
+import {CLRatePriceCapAdapter, IPriceCapAdapter} from '../src/contracts/CLRatePriceCapAdapter.sol';
 import {PriceCapAdapterStable} from '../src/contracts/PriceCapAdapterStable.sol';
 import {IChainlinkAggregator} from '../src/interfaces/IPriceCapAdapter.sol';
 import {IPriceCapAdapterStable} from '../src/interfaces/IPriceCapAdapterStable.sol';
 
 library CapAdaptersCodeAvalanche {
   address public constant AUSD_PRICE_FEED = 0x5C2d58627Fbe746f5ea24Ef6D618f09f8e3f0122;
+  address public constant sUSDe_USDe_AGGREGATOR = 0xb7441BBD0298aaeF4f2BbD40E8025Cf59cA6E8D5;
 
   function AUSDAdapterCode() internal pure returns (bytes memory) {
     return
@@ -26,10 +28,37 @@ library CapAdaptersCodeAvalanche {
         )
       );
   }
+
+  function sUSDeAdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(CLRatePriceCapAdapter).creationCode,
+        abi.encode(
+          IPriceCapAdapter.CapAdapterParams({
+            aclManager: AaveV3Avalanche.ACL_MANAGER,
+            baseAggregatorAddress: AaveV3AvalancheAssets.USDt_ORACLE,
+            ratioProviderAddress: sUSDe_USDe_AGGREGATOR,
+            pairDescription: 'Capped sUSDe / USDe / USD',
+            minimumSnapshotDelay: 14 days,
+            priceCapParams: IPriceCapAdapter.PriceCapUpdateParams({
+              snapshotRatio: 1_193972665854975048,
+              snapshotTimestamp: 1756871339, // 3-SEPT-2025
+              maxYearlyRatioGrowthPercent: 15_19
+            })
+          })
+        )
+      );
+  }
 }
 
 contract DeployAUSDAvalanche is AvalancheScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeAvalanche.AUSDAdapterCode());
+  }
+}
+
+contract DeploySUSDeAvalanche is AvalancheScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeAvalanche.sUSDeAdapterCode());
   }
 }

--- a/scripts/DeployPlasma.s.sol
+++ b/scripts/DeployPlasma.s.sol
@@ -3,18 +3,58 @@ pragma solidity ^0.8.0;
 
 import {GovV3Helpers} from 'aave-helpers/GovV3Helpers.sol';
 import {PlasmaScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
-import {AaveV3Plasma} from 'aave-address-book/AaveV3Plasma.sol';
+import {AaveV3Plasma, AaveV3PlasmaAssets} from 'aave-address-book/AaveV3Plasma.sol';
+import {SafeCast} from 'openzeppelin-contracts/contracts/utils/math/SafeCast.sol';
 import {CLRatePriceCapAdapter} from '../src/contracts/CLRatePriceCapAdapter.sol';
 import {PriceCapAdapterStable, IPriceCapAdapterStable} from '../src/contracts/PriceCapAdapterStable.sol';
 import {IPriceCapAdapter, IChainlinkAggregator} from '../src/interfaces/IPriceCapAdapter.sol';
+import {PendlePriceCapAdapter, IPendlePriceCapAdapter} from '../src/contracts/PendlePriceCapAdapter.sol';
 
 library CapAdaptersCodePlasma {
+  using SafeCast for uint256;
+
   address public constant weETH_eETH_AGGREGATOR = 0x00D7d8816E969EA6cA9125c3f5D279f9a6D253f6;
   address public constant sUSDe_USDe_AGGREGATOR = 0x802033dc696B92e5ED5bF68E1750F7Ed3329eabD;
+  address public constant PT_sUSDe_15_JAN_2026 = 0x02FCC4989B4C9D435b7ceD3fE1Ba4CF77BBb5Dd8;
+  address public constant PT_USDe_15_JAN_2026 = 0x93B544c330F60A2aa05ceD87aEEffB8D38FD8c9a;
 
   address public constant WETH_PRICE_FEED = 0x43A7dd2125266c5c4c26EB86cd61241132426Fe7;
   address public constant USDT_PRICE_FEED = 0x70b77FcdbE2293423e41AdD2FB599808396807BC;
   address public constant USDT_CAPO_PRICE_FEED = 0xdBbB0b5DD13E7AC9C56624834ef193df87b022c3;
+
+  function ptSUSDeJanuary2026AdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(PendlePriceCapAdapter).creationCode,
+        abi.encode(
+          IPendlePriceCapAdapter.PendlePriceCapAdapterParams({
+            assetToUsdAggregator: AaveV3PlasmaAssets.USDT0_ORACLE,
+            pendlePrincipalToken: PT_sUSDe_15_JAN_2026,
+            maxDiscountRatePerYear: uint256(36.82e16).toUint64(),
+            discountRatePerYear: uint256(8.38e16).toUint64(),
+            aclManager: address(AaveV3Plasma.ACL_MANAGER),
+            description: 'PT Capped sUSDe USDT/USD linear discount 15JAN2026'
+          })
+        )
+      );
+  }
+
+  function ptUSDeJanuary2026AdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(PendlePriceCapAdapter).creationCode,
+        abi.encode(
+          IPendlePriceCapAdapter.PendlePriceCapAdapterParams({
+            assetToUsdAggregator: AaveV3PlasmaAssets.USDT0_ORACLE,
+            pendlePrincipalToken: PT_USDe_15_JAN_2026,
+            maxDiscountRatePerYear: uint256(33.88e16).toUint64(),
+            discountRatePerYear: uint256(7.96e16).toUint64(),
+            aclManager: address(AaveV3Plasma.ACL_MANAGER),
+            description: 'PT Capped USDe USDT/USD linear discount 15JAN2026'
+          })
+        )
+      );
+  }
 
   function sUSDeAdapterParams() internal pure returns (bytes memory) {
     return
@@ -88,5 +128,17 @@ contract DeployWeEthPlasma is PlasmaScript {
 contract DeployUSDTPlasma is PlasmaScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodePlasma.USDTAdapterCode());
+  }
+}
+
+contract DeployPtSUSDe15JAN2026Plasma is PlasmaScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodePlasma.ptSUSDeJanuary2026AdapterCode());
+  }
+}
+
+contract DeployPtUSDe15JAN2026Plasma is PlasmaScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodePlasma.ptUSDeJanuary2026AdapterCode());
   }
 }

--- a/tests/avalanche/SUSDePriceCapAdapterTest.t.sol
+++ b/tests/avalanche/SUSDePriceCapAdapterTest.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import '../BaseTest.sol';
+
+import {AaveV3Avalanche, AaveV3AvalancheAssets} from 'aave-address-book/AaveV3Avalanche.sol';
+
+import {SUSDePriceCapAdapter} from '../../src/contracts/lst-adapters/SUSDePriceCapAdapter.sol';
+import {CapAdaptersCodeAvalanche} from '../../scripts/DeployAvalanche.s.sol';
+
+contract sUSDePriceCapAdapterAvalancheTest is BaseTest {
+  constructor()
+    BaseTest(
+      CapAdaptersCodeAvalanche.sUSDeAdapterCode(),
+      8,
+      ForkParams({network: 'avalanche', blockNumber: 69866570}),
+      'sUSDe_Avalanche'
+    )
+  {}
+
+  function _createAdapter(
+    IPriceCapAdapter.CapAdapterParams memory capAdapterParams
+  ) internal override returns (IPriceCapAdapter) {
+    return new SUSDePriceCapAdapter(capAdapterParams);
+  }
+}

--- a/tests/avalanche/SUSDePriceCapAdapterTest.t.sol
+++ b/tests/avalanche/SUSDePriceCapAdapterTest.t.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.0;
 
 import '../BaseTest.sol';
 
-import {AaveV3Avalanche, AaveV3AvalancheAssets} from 'aave-address-book/AaveV3Avalanche.sol';
-
 import {SUSDePriceCapAdapter} from '../../src/contracts/lst-adapters/SUSDePriceCapAdapter.sol';
 import {CapAdaptersCodeAvalanche} from '../../scripts/DeployAvalanche.s.sol';
 


### PR DESCRIPTION
_Please note: sUSDe/USDe exchange rate is taken from mainnet given the chainlink feed was not active at that timestamp_

**Deployed Contracts:**
- sUSDe avax: http://snowscan.xyz/address/0x8Fb2db0A3b25db76B9BE2013751F8390ea8E5f0A
- pt-sUSDe plasma: https://plasmascan.to/address/0x3eca1c7836eA09DB3dc85be7B5526Ce80E2609a1
- pt-USDe plasma: https://plasmascan.to/address/0x30cb6ff8649Cc02cEa91971D4730EebeD5A8D2F1

**Forum:**
- https://governance.aave.com/t/direct-to-aip-onboard-susde-and-usde-to-aave-v3-avalanche-instance/23081/3#p-58998-specification-13
- https://governance.aave.com/t/direct-to-aip-onboard-susde-and-usde-january-expiry-pt-tokens-on-aave-v3-plasma-instance/23196/4