### PR TITLE
chore: Add USDG CAPO + ptUSDG Sep 26 Deployment Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ node_modules
 
 # ignore foundry deploy artifacts
 broadcast/
+
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ SCRIPT_megaeth := DeployMegaEth
 SCRIPT_gnosis := DeployGnosis
 SCRIPT_xlayer := DeployXLayer
 
-## Per-chain verifier overrides: chains default to etherscan via --verify; blockscout chains need
-## explicit flags. Empty for any chain without an entry below.
+## Per-chain verifier overrides: chains default to etherscan via --verify; chains on other explorers
+## need explicit flags. Empty for any chain without an entry below.
 VERIFIER_ink := --verifier blockscout --verifier-url https://explorer.inkonchain.com/api/
+VERIFIER_xlayer := --verifier oklink --verifier-url https://www.oklink.com/api/v5/explorer/contract/verify-source-code-plugin/xlayer
 
 ### usage: make deploy adapter=WeEth chain=mainnet
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -38,30 +38,34 @@ SCRIPT_megaeth := DeployMegaEth
 SCRIPT_gnosis := DeployGnosis
 SCRIPT_xlayer := DeployXLayer
 
+## Per-chain verifier overrides: chains default to etherscan via --verify; blockscout chains need
+## explicit flags. Empty for any chain without an entry below.
+VERIFIER_ink := --verifier blockscout --verifier-url https://explorer.inkonchain.com/api/
+
 ### usage: make deploy adapter=WeEth chain=mainnet
 deploy:
 	@if [ -z "$(adapter)" ] || [ -z "$(chain)" ]; then \
 		echo "usage: make deploy adapter=WeEth chain=mainnet"; exit 1; fi
 	@script="${SCRIPT_$(chain)}"; \
 	if [ -z "$$script" ]; then echo "unknown chain: $(chain)"; exit 1; fi; \
-	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags)"; \
-	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags)
+	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags) ${VERIFIER_$(chain)}"; \
+	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags) ${VERIFIER_$(chain)}
 
 deploy-pk:
 	@if [ -z "$(adapter)" ] || [ -z "$(chain)" ]; then \
 		echo "usage: make deploy-pk adapter=WeEth chain=mainnet"; exit 1; fi
 	@script="${SCRIPT_$(chain)}"; \
 	if [ -z "$$script" ]; then echo "unknown chain: $(chain)"; exit 1; fi; \
-	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-pk)"; \
-	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-pk)
+	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-pk) ${VERIFIER_$(chain)}"; \
+	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-pk) ${VERIFIER_$(chain)}
 
 deploy-acc:
 	@if [ -z "$(adapter)" ] || [ -z "$(chain)" ] || [ -z "$(account)" ]; then \
 		echo "usage: make deploy-acc adapter=WeEth chain=mainnet account=deployer"; exit 1; fi
 	@script="${SCRIPT_$(chain)}"; \
 	if [ -z "$$script" ]; then echo "unknown chain: $(chain)"; exit 1; fi; \
-	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc)"; \
-	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc)
+	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc) ${VERIFIER_$(chain)}"; \
+	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc) ${VERIFIER_$(chain)} --resume
 
 # Utilities
 download :; cast source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ deploy-acc:
 	@script="${SCRIPT_$(chain)}"; \
 	if [ -z "$$script" ]; then echo "unknown chain: $(chain)"; exit 1; fi; \
 	echo "forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc) ${VERIFIER_$(chain)}"; \
-	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc) ${VERIFIER_$(chain)} --resume
+	forge script scripts/$$script.s.sol:Deploy$(adapter) --rpc-url $(chain) $(common-flags-acc) ${VERIFIER_$(chain)}
 
 # Utilities
 download :; cast source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}

--- a/scripts/DeployEthereum.s.sol
+++ b/scripts/DeployEthereum.s.sol
@@ -79,6 +79,7 @@ library CapAdaptersCodeEthereum {
   address public constant SKY_USD_FEED = 0xee10fE5E7aa92dd7b136597449c3d5813cFC5F18;
   address public constant PT_srUSDe_25_JUN_2026 = 0x619D75E3b790eBC21c289f2805Bb7177A7D732E2;
   address public constant PT_USDG_28_MAY_2026 = 0x9db38D74a0D29380899aD354121DfB521aDb0548;
+  address public constant PT_USDG_24_SEP_2026 = 0xc1906aeCf868749a2DeE203F59b904c0cf212140;
 
   function ptSrUSDeApril2026AdapterCode() internal pure returns (bytes memory) {
     return
@@ -867,6 +868,22 @@ library CapAdaptersCodeEthereum {
       );
   }
 
+  function ptUSDGSeptember2026AdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(PendlePriceCapAdapter).creationCode,
+        abi.encode(
+          IPendlePriceCapAdapter.PendlePriceCapAdapterParams({
+            assetToUsdAggregator: AaveV3EthereumAssets.USDG_ORACLE,
+            pendlePrincipalToken: PT_USDG_24_SEP_2026,
+            maxDiscountRatePerYear: uint256(10.38e16).toUint64(),
+            discountRatePerYear: uint256(4.5e16).toUint64(),
+            aclManager: address(AaveV3Ethereum.ACL_MANAGER),
+            description: 'PT Capped USDG Fixed USD linear discount 24SEP2026'
+          })
+        )
+      );
+  }
 }
 
 contract DeployLBTCEthereum is EthereumScript {
@@ -1130,5 +1147,11 @@ contract DeployPtSrUSDe25JUN2026Ethereum is EthereumScript {
 contract DeployPtUSDG28May2026Ethereum is EthereumScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeEthereum.ptUSDGMay2026AdapterCode());
+  }
+}
+
+contract DeployPtUSDG24Sep2026Ethereum is EthereumScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeEthereum.ptUSDGSeptember2026AdapterCode());
   }
 }

--- a/scripts/DeployEthereum.s.sol
+++ b/scripts/DeployEthereum.s.sol
@@ -701,6 +701,21 @@ library CapAdaptersCodeEthereum {
       );
   }
 
+  function USDGAdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(PriceCapAdapterStable).creationCode,
+        abi.encode(
+          IPriceCapAdapterStable.CapAdapterStableParams({
+            aclManager: AaveV3Ethereum.ACL_MANAGER,
+            assetToUsdAggregator: IChainlinkAggregator(ChainlinkEthereum.USDG__USD),
+            adapterDescription: 'Capped USDG / USD',
+            priceCap: int256(1.04 * 1e8)
+          })
+        )
+      );
+  }
+
   function syrupUSDCAdapterCode() internal pure returns (bytes memory) {
     return
       abi.encodePacked(
@@ -874,12 +889,12 @@ library CapAdaptersCodeEthereum {
         type(PendlePriceCapAdapter).creationCode,
         abi.encode(
           IPendlePriceCapAdapter.PendlePriceCapAdapterParams({
-            assetToUsdAggregator: AaveV3EthereumAssets.USDG_ORACLE,
+            assetToUsdAggregator: GovV3Helpers.predictDeterministicAddress(USDGAdapterCode()),
             pendlePrincipalToken: PT_USDG_24_SEP_2026,
             maxDiscountRatePerYear: uint256(10.38e16).toUint64(),
             discountRatePerYear: uint256(4.5e16).toUint64(),
             aclManager: address(AaveV3Ethereum.ACL_MANAGER),
-            description: 'PT Capped USDG Fixed USD linear discount 24SEP2026'
+            description: 'PT Capped USDG USDG/USD linear discount 24SEP2026'
           })
         )
       );
@@ -1147,6 +1162,12 @@ contract DeployPtSrUSDe25JUN2026Ethereum is EthereumScript {
 contract DeployPtUSDG28May2026Ethereum is EthereumScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeEthereum.ptUSDGMay2026AdapterCode());
+  }
+}
+
+contract DeployUSDGEthereum is EthereumScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeEthereum.USDGAdapterCode());
   }
 }
 

--- a/scripts/DeployInk.s.sol
+++ b/scripts/DeployInk.s.sol
@@ -12,6 +12,7 @@ import {IPriceCapAdapter} from '../src/interfaces/IPriceCapAdapter.sol';
 library CapAdaptersCodeInk {
   address public constant USDT_PRICE_FEED = 0x176A9536feaC0340de9f9811f5272E39E80b424f;
   address public constant USDC_PRICE_FEED = 0xCffB7b219A6Ee67468B02fE4e34E33Fd393c76Ff;
+  address public constant USDG_PRICE_FEED = 0xdb3B1fa77CF2c9597f9d4871Bed1Df03D096fdf3;
   address public constant ETH_PRICE_FEED = 0x163131609562E578754aF12E998635BfCa56712C;
   address public constant WrsETH_ETH_PRICE_FEED = 0x800Ca870416CDFEf77991036B8e1f2E51623996E;
   address public constant WsTETH_stETH_PRICE_FEED = 0x0eA85E34b26ff769e63c24776baBA60782446166;
@@ -35,11 +36,26 @@ library CapAdaptersCodeInk {
       );
   }
 
-  function USDGAdapterCode() internal pure returns (bytes memory) {
+  function fixedUSDGAdapterCode() internal pure returns (bytes memory) {
     return
       abi.encodePacked(
         type(FixedPriceAdapter).creationCode,
         abi.encode(address(AaveV3InkWhitelabel.ACL_MANAGER), 8, int256(1 * 1e8), 'Fixed USDG/USD')
+      );
+  }
+
+  function USDGAdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(PriceCapAdapterStable).creationCode,
+        abi.encode(
+          IPriceCapAdapterStable.CapAdapterStableParams({
+            aclManager: AaveV3InkWhitelabel.ACL_MANAGER,
+            assetToUsdAggregator: IChainlinkAggregator(USDG_PRICE_FEED),
+            adapterDescription: 'Capped USDG/USD',
+            priceCap: int256(1.04 * 1e8)
+          })
+        )
       );
   }
 
@@ -182,6 +198,12 @@ library CapAdaptersCodeInk {
           })
         )
       );
+  }
+}
+
+contract DeployFixedUSDGInk is InkScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeInk.fixedUSDGAdapterCode());
   }
 }
 

--- a/scripts/DeployXLayer.s.sol
+++ b/scripts/DeployXLayer.s.sol
@@ -14,6 +14,7 @@ import {IPriceCapAdapterStable} from '../src/interfaces/IPriceCapAdapterStable.s
 
 library CapAdaptersCodeXLayer {
   address public constant CL_USDT_USD_FEED = 0xb928a0678352005a2e51F614efD0b54C9830dB80;
+  address public constant CL_USDG_USD_FEED = 0x385C6bDDE06b0E438319bF4ddBfFe51C521ABf3D;
   address public constant CL_SOL_USD_FEED = 0xF959E1B5cA535C28aD24F7f672Bf1A93900810cF;
   address public constant CL_ETH_USD_FEED = 0x8b85b50535551F8E8cDAF78dA235b5Cf1005907b;
 
@@ -77,30 +78,51 @@ library CapAdaptersCodeXLayer {
       );
   }
 
+  function USDGAdapterCode() internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        type(PriceCapAdapterStable).creationCode,
+        abi.encode(
+          IPriceCapAdapterStable.CapAdapterStableParams({
+            aclManager: AaveV3XLayer.ACL_MANAGER,
+            assetToUsdAggregator: IChainlinkAggregator(CL_USDG_USD_FEED),
+            adapterDescription: 'Capped USDG / USD',
+            priceCap: int256(1.04 * 1e8)
+          })
+        )
+      );
+  }
+
   function oneUSDFixedAdapterCode() internal pure returns (bytes memory) {
     return abi.encodePacked(type(OneUSDFixedAdapter).creationCode);
   }
 }
 
-contract DeployUSDT is XLayerScript {
+contract DeployUSDTXLayer is XLayerScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeXLayer.USDTAdapterCode());
   }
 }
 
-contract DeployOneUsd is XLayerScript {
+contract DeployUSDGXLayer is XLayerScript {
+  function run() external broadcast {
+    GovV3Helpers.deployDeterministic(CapAdaptersCodeXLayer.USDGAdapterCode());
+  }
+}
+
+contract DeployOneUsdXLayer is XLayerScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeXLayer.oneUSDFixedAdapterCode());
   }
 }
 
-contract DeployXOKSOL is XLayerScript {
+contract DeployXOKSOLXLayer is XLayerScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeXLayer.xOKSOLAdapterCode());
   }
 }
 
-contract DeployXBETH is XLayerScript {
+contract DeployXBETHXLayer is XLayerScript {
   function run() external broadcast {
     GovV3Helpers.deployDeterministic(CapAdaptersCodeXLayer.xBETHAdapterCode());
   }

--- a/tests/adapters/USDGPriceCapAdapterTest.t.sol
+++ b/tests/adapters/USDGPriceCapAdapterTest.t.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import '../BaseStableTest.sol';
+import {CapAdaptersCodeEthereum} from '../../scripts/DeployEthereum.s.sol';
+
+contract USDGEthereumTest is BaseStableTest {
+  constructor()
+    BaseStableTest(
+      CapAdaptersCodeEthereum.USDGAdapterCode(),
+      14,
+      ForkParams({network: 'mainnet', blockNumber: 24319000})
+    )
+  {}
+}


### PR DESCRIPTION
This PR deploys, in order:

1. **USDG CAPO (Ethereum)** — a new `PriceCapAdapterStable` with a **1.04 price cap**, backed by the USDG/USD Chainlink feed (`0x14f0737d6b705259e521EA6E9E3506AC78dBd311`), replacing the previous constant-`1` fixed USDG feed.
   - https://etherscan.io/address/0x83d20deedcd4ac1313496c8cbcaad0fa298c0ce4
2. **PT USDG 24SEP2026 (Ethereum)** — the Pendle PT price feed, now pointing at the new USDG CAPO above (instead of the constant-1 `USDG_ORACLE`).
   - https://etherscan.io/address/0x89f6eb404abf19fe817426dd2e2e0f14d1a5712e

The PT adapter references the CAPO via `GovV3Helpers.predictDeterministicAddress`, so the deterministic addresses are consistent regardless of deploy order (deploy the CAPO first, then the PT feed).

Deploy contracts: `DeployUSDGEthereum`, then `DeployPtUSDG24Sep2026Ethereum`.

It also deploys the equivalent USDG CAPO on the chains where the Ink whitelabel instance sources USDG, each a `PriceCapAdapterStable` with a **1.04 price cap** backed by the local USDG/USD Chainlink feed, replacing the previous constant-`1` fixed USDG feed:

3. **USDG CAPO (Ink)** — backed by the Ink USDG/USD Chainlink feed (`0xdb3B1fa77CF2c9597f9d4871Bed1Df03D096fdf3`). Deploy contract: `DeployUSDGCappedInk`.
   - https://explorer.inkonchain.com/address/0x32b1f1A1D3423dE69cf1f75092eCfDc5090d6624
4. **USDG CAPO (X Layer)** — backed by the X Layer USDG/USD Chainlink feed (`0x385C6bDDE06b0E438319bF4ddBfFe51C521ABf3D`). Deploy contract: `DeployUSDGXLayer`.
   - https://www.oklink.com/x-layer/evm/address/0xe00b2732396a1f047d4a00e0165025a9cf400245/contract

- gov post: https://governance.aave.com/t/technical-maintenance-proposals/15274/132
