### PR TITLE
docs: correct v4 price feed requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See [how-to.md](./how-to.md) for detailed instructions on adding LST or stableco
 
 ## Aave V4 compatibility
 
-The Aave v3 Oracle and the current Aave v4 Oracle both consume `latestAnswer()`. When registering a source, the Aave v4 Oracle also calls `decimals()` and requires the source decimals to match the Oracle decimals. See the Aave v4 [`AaveOracle`](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/AaveOracle.sol#L80-L87) implementation and its minimal [`IPriceFeed`](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/interfaces/IPriceFeed.sol) interface.
+The Aave v3 Oracle and the current Aave v4 Oracle both consume `latestAnswer()`. When registering a source, the Aave v4 Oracle also [calls `decimals()` and requires the source decimals to match the Oracle decimals](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/AaveOracle.sol#L48).
 
 `latestRoundData()` is not required by the current Aave v4 Oracle. Adapters may still implement [`IExtendedFeed`](./src/interfaces/IExtendedFeed.sol) to expose it for compatibility with other consumers; see [`OneUSDFixedAdapter.sol`](./src/contracts/misc-adapters/OneUSDFixedAdapter.sol) for an example.
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,9 @@ See [how-to.md](./how-to.md) for detailed instructions on adding LST or stableco
 
 ## Aave V4 compatibility
 
-The currently audited adapters expose only `latestAnswer()`, which is used by Aave v3 Oracle. Aave v4 Oracle uses `latestRoundData()` instead.
+The Aave v3 Oracle and the current Aave v4 Oracle both consume `latestAnswer()`. When registering a source, the Aave v4 Oracle also calls `decimals()` and requires the source decimals to match the Oracle decimals. See the Aave v4 [`AaveOracle`](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/AaveOracle.sol#L80-L87) implementation and its minimal [`IPriceFeed`](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/interfaces/IPriceFeed.sol) interface.
 
-**For v4 compatibility:**
-
-1. New adapters must inherit from the [`IExtendedFeed`](./src/interfaces//IExtendedFeed.sol) interface, which implements the `latestRoundData()` function.
-
-2. Implement it on the adapter (see `latestRoundData()` example in [`OneUSDFixedAdapter.sol`](./src/contracts/misc-adapters/OneUSDFixedAdapter.sol)).
+`latestRoundData()` is not required by the current Aave v4 Oracle. Adapters may still implement [`IExtendedFeed`](./src/interfaces/IExtendedFeed.sol) to expose it for compatibility with other consumers; see [`OneUSDFixedAdapter.sol`](./src/contracts/misc-adapters/OneUSDFixedAdapter.sol) for an example.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ See [how-to.md](./how-to.md) for detailed instructions on adding LST or stableco
 
 ## Aave V4 compatibility
 
-The Aave v3 Oracle and the current Aave v4 Oracle both consume `latestAnswer()`. When registering a source, the Aave v4 Oracle also [calls `decimals()` and requires the source decimals to match the Oracle decimals](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/AaveOracle.sol#L48).
+The Aave v3 Oracle and the current Aave v4 Oracle both consume `latestAnswer()` function. When registering a price source, the Aave V4 Oracle also calls `decimals()` function and [requires the price source's decimals to match the Oracle's decimals](https://github.com/aave/aave-v4/blob/496200b791c02e4a009188fc48448d11f2eef3c6/src/spoke/AaveOracle.sol#L48).
 
-`latestRoundData()` is not required by the current Aave v4 Oracle. Adapters may still implement [`IExtendedFeed`](./src/interfaces/IExtendedFeed.sol) to expose it for compatibility with other consumers; see [`OneUSDFixedAdapter.sol`](./src/contracts/misc-adapters/OneUSDFixedAdapter.sol) for an example.
+The `latestRoundData()` function is not required by the Aave V4 Oracle. Adapters may still implement [`IExtendedFeed`](./src/interfaces/IExtendedFeed.sol) to expose it for compatibility with other consumers; see [`OneUSDFixedAdapter.sol`](./src/contracts/misc-adapters/OneUSDFixedAdapter.sol) for an example.
 
 ## Security
 


### PR DESCRIPTION
Corrects the README compatibility guidance after aave/aave-v4#1221 switched the v4 AaveOracle from `latestRoundData()` to `latestAnswer()`.

- Documents the current `latestAnswer()` and `decimals()` requirements.
- Clarifies that `IExtendedFeed` and `latestRoundData()` remain optional compatibility features for other consumers.
- Links to the pinned v4 implementation and minimal price-feed interface.